### PR TITLE
Use LOGIN_REDIRECT_URL setting in login view.

### DIFF
--- a/cas_provider/views.py
+++ b/cas_provider/views.py
@@ -11,9 +11,11 @@ from utils import create_service_ticket
 
 __all__ = ['login', 'validate', 'logout']
 
-def login(request, template_name='cas/login.html', success_redirect='/accounts/'):
-    if settings.LOGIN_REDIRECT_URL:
-        success_redirect = settings.LOGIN_REDIRECT_URL
+def login(request, template_name='cas/login.html', success_redirect=None ):
+    if not success_redirect:
+        success_redirect = settings.get('LOGIN_REDIRECT_URL', None)
+    if not success_redirect:
+        success_redirect = '/accounts/profile/'
     service = request.GET.get('service', None)
     if request.user.is_authenticated():
         if service is not None:

--- a/cas_provider/views.py
+++ b/cas_provider/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as auth_login, logout as auth_logout
+from django.conf import settings
 
 from forms import LoginForm
 from models import ServiceTicket, LoginTicket
@@ -11,6 +12,8 @@ from utils import create_service_ticket
 __all__ = ['login', 'validate', 'logout']
 
 def login(request, template_name='cas/login.html', success_redirect='/accounts/'):
+    if settings.LOGIN_REDIRECT_URL:
+        success_redirect = settings.LOGIN_REDIRECT_URL
     service = request.GET.get('service', None)
     if request.user.is_authenticated():
         if service is not None:


### PR DESCRIPTION
Proposed fix for issue #3, take 2.

The code uses the value of `success_redirect` if provided in the URL patterns.  If unset, the code falls back to the `LOGIN_REDIRECT_URL` setting.  If that it still not enough, it uses the default setting for `LOGIN_REDIRECT_URL` as per [Django documentation](https://docs.djangoproject.com/en/dev/ref/settings/#login-redirect-url).  Note that this breaks clients because the old default was `/accounts/`.
